### PR TITLE
Use local transformers model for KPI simulation

### DIFF
--- a/simulate_kpis.py
+++ b/simulate_kpis.py
@@ -1,44 +1,45 @@
 #!/usr/bin/env python3
-import requests
+"""Simulate fundraising KPIs using a local language model."""
+
+import argparse
 import json
 import csv
 import tqdm
+from transformers import pipeline
 import variants  # assumes variants.py defines `variants` list
 
-# Configuration
-GENERATIVE_SERVER_URL = "http://57.129.18.204:51001"
-
-def simulate_kpi(variant):
-    """Call LLM endpoint to predict KPIs for one strategy variant."""
-    payload = {
-        "input": (
-            f"Estimate these KPI metrics for the fundraising strategy:\n"
-            f"- Ask Amount: {variant['ask']}\n"
-            f"- Format: {variant['format']}\n"
-            f"- Tone: {variant['tone']}\n"
-            f"- Channel: {variant['channel']}\n"
-            "Return ONLY valid JSON with keys: rsvp_pct, conv_rate, avg_gift_hkd, retention_pct."
-        ),
-        "instructions": "Provide numeric values only. No extra text or markdown."
-    }
+def simulate_kpi(variant, generator):
+    """Generate simulated KPI metrics for one strategy variant."""
+    prompt = (
+        f"Estimate these KPI metrics for the fundraising strategy:\n"
+        f"- Ask Amount: {variant['ask']}\n"
+        f"- Format: {variant['format']}\n"
+        f"- Tone: {variant['tone']}\n"
+        f"- Channel: {variant['channel']}\n"
+        "Return ONLY valid JSON with keys: rsvp_pct, conv_rate, avg_gift_hkd, retention_pct."
+    )
 
     try:
-        resp = requests.post(
-            f"{GENERATIVE_SERVER_URL}/generate-text",
-            json=payload,
-            timeout=90
-        )
-        resp.raise_for_status()
-        return json.loads(resp.json()["text"].strip())
-    except requests.exceptions.RequestException as e:
+        result = generator(prompt, max_new_tokens=128, do_sample=False)
+        text = result[0]["generated_text"]
+        if text.startswith(prompt):
+            text = text[len(prompt):]
+        return json.loads(text.strip())
+    except Exception as e:
         print(f"❌ Error simulating {variant}: {e}")
         return {"rsvp_pct": 0, "conv_rate": 0, "avg_gift_hkd": 0, "retention_pct": 0}
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Simulate KPIs with a local model")
+    parser.add_argument("--model", default="gpt2", help="HF model name or path")
+    args = parser.parse_args()
+
+    generator = pipeline("text-generation", model=args.model)
+
     rows = []
     print("🔁 Running KPI simulation for each variant…")
     for v in tqdm.tqdm(variants.variants[:150], desc="Simulating"):
-        kpi = simulate_kpi(v)
+        kpi = simulate_kpi(v, generator)
         v.update(kpi)
         # Composite score
         revenue = kpi["avg_gift_hkd"] * kpi["conv_rate"]


### PR DESCRIPTION
## Summary
- remove HTTP calls from `simulate_kpis.py`
- load a transformers text-generation pipeline from CLI
- generate KPI JSON directly from the model output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864ca6b13ac83339286ad44a884f29a