### PR TITLE
Add KPI baseline heuristics

### DIFF
--- a/kpi_utils.py
+++ b/kpi_utils.py
@@ -1,0 +1,82 @@
+"""Utility helpers for KPI baseline estimation and adjustment."""
+
+from typing import Dict, Any
+import pandas as pd
+
+
+def baseline_kpis(event: Dict[str, Any], donors: pd.DataFrame) -> Dict[str, float]:
+    """Estimate baseline KPIs from historical event data and selected donors.
+
+    Parameters
+    ----------
+    event : dict
+        Event dictionary with optional ``prev_years`` and ``goal_amount`` keys.
+    donors : pandas.DataFrame
+        DataFrame of selected donors. Must contain a column with average gift
+        amounts, e.g. ``avg_gift_hkd`` or ``avg_gift_usd``.
+    Returns
+    -------
+    dict
+        Dictionary with keys ``conv_rate``, ``avg_gift``, and ``revenue`` plus
+        averages from ``prev_years`` if available.
+    """
+    prev = event.get("prev_years") or []
+    avg_attendees = (
+        sum(p.get("attendees", 0) for p in prev) / len(prev) if prev else 0
+    )
+    avg_total = (
+        sum(p.get("total_raised", 0) for p in prev) / len(prev) if prev else 0
+    )
+
+    donor_count = len(donors)
+    if donor_count == 0:
+        return {
+            "avg_prev_attendees": avg_attendees,
+            "avg_prev_total": avg_total,
+            "conv_rate": 0.0,
+            "avg_gift": 0.0,
+            "revenue": 0.0,
+        }
+
+    gift_col = "avg_gift_hkd" if "avg_gift_hkd" in donors.columns else "avg_gift_usd"
+    donor_avg_gift = float(donors[gift_col].mean())
+
+    conv_rate = min(avg_attendees / donor_count, 1.0) if avg_attendees else 0.1
+    avg_gift = avg_total / avg_attendees if avg_attendees else donor_avg_gift
+    revenue = conv_rate * avg_gift * donor_count
+
+    return {
+        "avg_prev_attendees": avg_attendees,
+        "avg_prev_total": avg_total,
+        "conv_rate": conv_rate,
+        "avg_gift": avg_gift,
+        "revenue": revenue,
+    }
+
+
+def adjust_with_baseline(
+    event: Dict[str, Any],
+    donors: pd.DataFrame,
+    llm_kpis: Dict[str, float],
+) -> Dict[str, float]:
+    """Adjust LLM-generated KPIs so estimated revenue meets the event goal."""
+    baseline = baseline_kpis(event, donors)
+    goal = event.get("goal_amount", baseline["revenue"])
+    donor_count = len(donors)
+    if donor_count == 0:
+        return llm_kpis
+
+    revenue = llm_kpis.get("conv_rate", 0) * llm_kpis.get("avg_gift_hkd", 0) * donor_count
+    if revenue < goal:
+        llm_kpis["conv_rate"] = max(llm_kpis.get("conv_rate", 0), baseline["conv_rate"])
+        llm_kpis["avg_gift_hkd"] = max(
+            llm_kpis.get("avg_gift_hkd", 0), baseline["avg_gift"]
+        )
+        revenue = llm_kpis["conv_rate"] * llm_kpis["avg_gift_hkd"] * donor_count
+        if revenue < goal:
+            llm_kpis["avg_gift_hkd"] = goal / (llm_kpis["conv_rate"] * donor_count)
+
+    llm_kpis["baseline_revenue"] = baseline["revenue"]
+    llm_kpis["estimated_revenue"] = llm_kpis["conv_rate"] * llm_kpis["avg_gift_hkd"] * donor_count
+    return llm_kpis
+

--- a/simulate_kpis.py
+++ b/simulate_kpis.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-import requests
+import argparse
 import json
 import csv
+from typing import List, Dict
+from pathlib import Path
+
+import requests
+import pandas as pd
 import tqdm
 import variants  # assumes variants.py defines `variants` list
+from kpi_utils import adjust_with_baseline
 
 # Configuration
 GENERATIVE_SERVER_URL = "http://57.129.18.204:51001"
@@ -34,26 +40,67 @@ def simulate_kpi(variant):
         print(f"❌ Error simulating {variant}: {e}")
         return {"rsvp_pct": 0, "conv_rate": 0, "avg_gift_hkd": 0, "retention_pct": 0}
 
-if __name__ == "__main__":
+def run_simulation(
+    variants_list: List[Dict],
+    event: Dict | None,
+    donors: pd.DataFrame | None,
+    out_file: str,
+):
     rows = []
     print("🔁 Running KPI simulation for each variant…")
-    for v in tqdm.tqdm(variants.variants[:150], desc="Simulating"):
+    for v in tqdm.tqdm(variants_list[:150], desc="Simulating"):
         kpi = simulate_kpi(v)
+        if event is not None and donors is not None:
+            kpi = adjust_with_baseline(event, donors, kpi)
         v.update(kpi)
         # Composite score
         revenue = kpi["avg_gift_hkd"] * kpi["conv_rate"]
         v["score"] = round(
-            0.4 * revenue +
-            0.25 * kpi["conv_rate"] +
-            0.2 * kpi["retention_pct"] +
-            0.15 * kpi["rsvp_pct"], 4
+            0.4 * revenue
+            + 0.25 * kpi["conv_rate"]
+            + 0.2 * kpi["retention_pct"]
+            + 0.15 * kpi["rsvp_pct"],
+            4,
         )
         rows.append(v)
 
     if rows:
         keys = list(rows[0].keys())
-        with open("simulation_results.csv", "w", newline="", encoding="utf-8") as f:
+        with open(out_file, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=keys)
             writer.writeheader()
             writer.writerows(rows)
-        print(f"✅ Saved simulation_results.csv ({len(rows)} rows)")
+        print(f"✅ Saved {out_file} ({len(rows)} rows)")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Simulate fundraising KPIs via LLM")
+    ap.add_argument(
+        "--proposals",
+        default="variants.json",
+        help="JSON file containing strategy variants",
+    )
+    ap.add_argument(
+        "--output",
+        default="simulation_results.csv",
+        help="CSV file to store results",
+    )
+    ap.add_argument("--event_json", help="Event JSON (single event or list)")
+    ap.add_argument("--donor_csv", help="CSV of selected donors")
+    args = ap.parse_args()
+
+    variants_list = variants.variants
+    if args.proposals and args.proposals != "variants.json":
+        with open(args.proposals, "r", encoding="utf-8") as f:
+            variants_list = json.load(f)
+
+    event = None
+    donors = None
+    if args.event_json and Path(args.event_json).exists():
+        with open(args.event_json, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            event = data[0] if isinstance(data, list) else data
+    if args.donor_csv and Path(args.donor_csv).exists():
+        donors = pd.read_csv(args.donor_csv)
+
+    run_simulation(variants_list, event, donors, args.output)


### PR DESCRIPTION
## Summary
- add `kpi_utils.py` providing `baseline_kpis` and `adjust_with_baseline`
- integrate baseline adjustment into `simulate_kpis.py` with CLI options

## Testing
- `python -m py_compile kpi_utils.py simulate_kpis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864ca79dfe88333b5e85d3d2a7f376d