### PR TITLE
Switch to local Gemma model

### DIFF
--- a/chatgpt_api.py
+++ b/chatgpt_api.py
@@ -1,30 +1,30 @@
-import requests
+"""Simple utility to generate a short report using a local Gemma model."""
+
 import json
+from transformers import pipeline
 
 # Configuration
-GENERATIVE_SERVER_URL = "http://57.129.18.204:51001"
+MODEL_NAME = "gemma-4b"
+_GENERATOR = pipeline("text-generation", model=MODEL_NAME)
 
 
 def generate_ai_report(topic, report_type="analysis"):
     """Generate an AI report on a given topic"""
 
-    payload = {
-        "input": f"Write a comprehensive {report_type} report about {topic}",
-        "instructions": "Structure the report with clear sections: Executive Summary, Key Findings, Analysis, and Recommendations. Keep it professional and informative."
-    }
+    prompt = (
+        f"Write a comprehensive {report_type} report about {topic}\n"
+        "Structure the report with clear sections: Executive Summary, Key Findings, Analysis, and Recommendations. "
+        "Keep it professional and informative."
+    )
 
     try:
-        response = requests.post(
-            f"{GENERATIVE_SERVER_URL}/generate-text",
-            json=payload,
-            timeout=60
-        )
-        response.raise_for_status()
+        result = _GENERATOR(prompt, max_new_tokens=1024, do_sample=False)
+        text = result[0]["generated_text"]
+        if text.startswith(prompt):
+            text = text[len(prompt):]
+        return text.strip()
 
-        result = response.json()
-        return result["text"]
-
-    except requests.exceptions.RequestException as e:
+    except Exception as e:
         return f"Error generating report: {e}"
 
 

--- a/match_events.py
+++ b/match_events.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 # generate_events.py
-import requests
+"""Generate sample events using a local Gemma model."""
+
 import json
 import sys
+from transformers import pipeline
 
 # Configuration
-GENERATIVE_SERVER_URL = "http://57.129.18.204:51001"
+MODEL_NAME = "gemma-4b"
+_GENERATOR = pipeline("text-generation", model=MODEL_NAME)
 
 def generate_event_list(num_events: int = 50):
     """
@@ -13,27 +16,23 @@ def generate_event_list(num_events: int = 50):
     """
 
     # ---------- ① 只改這裡 ----------
-    payload = {
-        "input": f"Generate a list of {num_events} charity fundraising events. Return ONLY valid JSON - an array of objects - no markdown, no code fences.",
-        "instructions": "Each event object MUST contain the following keys exactly: event_id, title, description, format, modality_ratio (object with in_person, online), venue (object with name, city, lat, lon), date_start, date_end, cause, sub_cause, keywords (array), target_segments (array), religious_affinity, age_range (array of two ints), language, goal_amount, donation_tiers (array of {label, min}), volunteer_slots, comm_channels (array), send_schedule (object with save_the_date, reminder), prev_years (array of {year, attendees, total_raised}), sponsor_names (array), matching_ratio, tax_deductible. Values should resemble real Hong Kong / Macau charity events (e.g., Jockey Club, World Vision). Dates in 2025, goal_amount in HKD, and use ISO-8601 for all timestamps."
-    }
+    prompt = (
+        f"Generate a list of {num_events} charity fundraising events. Return ONLY valid JSON - an array of objects - no markdown, no code fences.\n"
+        "Each event object MUST contain the following keys exactly: event_id, title, description, format, modality_ratio (object with in_person, online), venue (object with name, city, lat, lon), date_start, date_end, cause, sub_cause, keywords (array), target_segments (array), religious_affinity, age_range (array of two ints), language, goal_amount, donation_tiers (array of {label, min}), volunteer_slots, comm_channels (array), send_schedule (object with save_the_date, reminder), prev_years (array of {year, attendees, total_raised}), sponsor_names (array), matching_ratio, tax_deductible. Values should resemble real Hong Kong / Macau charity events (e.g., Jockey Club, World Vision). Dates in 2025, goal_amount in HKD, and use ISO-8601 for all timestamps."
+    )
     # ---------------------------------
 
     try:
-        response = requests.post(
-            f"{GENERATIVE_SERVER_URL}/generate-text",
-            json=payload,
-            timeout=450
-        )
-        response.raise_for_status()
-        result = response.json()
-
+        result = _GENERATOR(prompt, max_new_tokens=2048, do_sample=False)
+        events_json_str = result[0]["generated_text"]
+        if events_json_str.startswith(prompt):
+            events_json_str = events_json_str[len(prompt):]
+        events_json_str = events_json_str.strip()
         # 驗證是否為合法 JSON（若失敗會丟 JSONDecodeError）
-        events_json_str = result["text"].strip()
         json.loads(events_json_str)
         return events_json_str
 
-    except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
+    except (json.JSONDecodeError, Exception) as e:
         return f"Error generating events list: {e}"
 
 # ---------- ② 只改這裡 ----------


### PR DESCRIPTION
## Summary
- replace HTTP calls with local Gemma 4b model
- update grant proposal helper to use the new generator
- update event matching utilities
- rewrite event_generate to rely on a pipeline
- clean up ChatGPT API demo

## Testing
- `python -m py_compile chatgpt_api.py grant_assistant.py match_events.py event_generate.py`

------
https://chatgpt.com/codex/tasks/task_b_6864d72730388333b1aaca875f9da712