### PR TITLE
Fix match & KPI options

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,21 +5,13 @@ import subprocess, sys, textwrap
 task_map = {
     1: ["python", "gen_donor_dataset.py"],
     2: ["python", "build_rag_index.py",
-        "--donor_csv", "donors_1k.csv",
+        "--donor_csv", "output/donors_fake.csv",
         "--out_dir", "models"],
     3: ["python", "event_generate.py"],
     4: ["python", "search_events.py",
         "--index_dir", "models",
-        "--events_json", "events_list.json",
+        "--events_json", "sample_events.json",
         "--top_k", "5"],
-    5: ["python", "match_events.py",
-        "--events_json", "events_list.json",
-        "--donor_csv", "donors_1k.csv",
-        "--index_dir", "models",
-        "--top_k", "5"],
-    6: ["python", "simulate_kpis.py",
-        "--proposals", "variants.json",
-        "--output", "simulation_results.csv"],
     7: ["python", "generate_kpis_report.py"],
     8: ["python", "grant_assistant.py"],
 }
@@ -45,9 +37,28 @@ while True:
         print("Please enter a number."); continue
     if choice == 0:
         sys.exit(0)
-    cmd = task_map.get(choice)
-    if not cmd:
-        print("Invalid choice"); continue
+    if choice == 5:
+        event_id = input("Enter event ID to match (e.g., hk001): ").strip()
+        cmd = [
+            "python", "match_events.py",
+            "--events_json", "sample_events.json",
+            "--event_id", event_id,
+            "--donor_csv", "output/donors_fake.csv",
+            "--index_dir", "models",
+            "--top_k", "5",
+        ]
+    elif choice == 6:
+        event_id = input("Enter event ID for KPI simulation (e.g., hk001): ").strip()
+        cmd = [
+            "python", "simulate_kpis.py",
+            "--events_json", "sample_events.json",
+            "--event_id", event_id,
+            "--donor_csv", "output/donors_fake.csv",
+        ]
+    else:
+        cmd = task_map.get(choice)
+        if not cmd:
+            print("Invalid choice"); continue
     print("\n⇢ Running:", " ".join(cmd))
     try:
         subprocess.run(cmd, check=True)

--- a/match_events.py
+++ b/match_events.py
@@ -1,48 +1,37 @@
 #!/usr/bin/env python3
-# generate_events.py
-"""Generate sample events using a local Gemma model."""
+"""Simple heuristic donor matching for a selected event."""
 
+import argparse
 import json
-import sys
-from transformers import pipeline
+import pandas as pd
 
-# Configuration
-MODEL_NAME = "gemma-4b"
-_GENERATOR = pipeline("text-generation", model=MODEL_NAME)
 
-def generate_event_list(num_events: int = 50):
-    """
-    呼叫 LLM 產生指定數量的捐款活動清單（JSON 字串）。
-    """
+def load_event(events, event_id: str) -> dict:
+    for ev in events:
+        if ev.get("event_id") == event_id:
+            return ev
+    raise ValueError(f"Event id {event_id} not found")
 
-    # ---------- ① 只改這裡 ----------
-    prompt = (
-        f"Generate a list of {num_events} charity fundraising events. Return ONLY valid JSON - an array of objects - no markdown, no code fences.\n"
-        "Each event object MUST contain the following keys exactly: event_id, title, description, format, modality_ratio (object with in_person, online), venue (object with name, city, lat, lon), date_start, date_end, cause, sub_cause, keywords (array), target_segments (array), religious_affinity, age_range (array of two ints), language, goal_amount, donation_tiers (array of {label, min}), volunteer_slots, comm_channels (array), send_schedule (object with save_the_date, reminder), prev_years (array of {year, attendees, total_raised}), sponsor_names (array), matching_ratio, tax_deductible. Values should resemble real Hong Kong / Macau charity events (e.g., Jockey Club, World Vision). Dates in 2025, goal_amount in HKD, and use ISO-8601 for all timestamps."
-    )
-    # ---------------------------------
 
-    try:
-        result = _GENERATOR(prompt, max_new_tokens=2048, do_sample=False)
-        events_json_str = result[0]["generated_text"]
-        if events_json_str.startswith(prompt):
-            events_json_str = events_json_str[len(prompt):]
-        events_json_str = events_json_str.strip()
-        # 驗證是否為合法 JSON（若失敗會丟 JSONDecodeError）
-        json.loads(events_json_str)
-        return events_json_str
-
-    except (json.JSONDecodeError, Exception) as e:
-        return f"Error generating events list: {e}"
-
-# ---------- ② 只改這裡 ----------
 if __name__ == "__main__":
-    # Generate a report
-    events_json = generate_event_list(50)
+    ap = argparse.ArgumentParser(description="Match donors to an event by cause")
+    ap.add_argument("--events_json", required=True, help="Path to events JSON")
+    ap.add_argument("--event_id", required=True, help="ID of the event")
+    ap.add_argument("--donor_csv", required=True, help="CSV of donors")
+    ap.add_argument("--top_k", type=int, default=5, help="Number of donors to show")
+    args = ap.parse_args()
 
-    # Save to file
-    with open("events_list.json", "w", encoding="utf-8") as f:
-        f.write(events_json)
+    events = json.load(open(args.events_json, "r", encoding="utf-8"))
+    event = load_event(events, args.event_id)
 
-    print("Events JSON generated and saved to 'events_list.json'")
-    print(f"Characters: {len(events_json)}")
+    donors = pd.read_csv(args.donor_csv)
+    matches = donors[donors["primary_cause"].str.lower() == str(event.get("cause", "")).lower()]
+    if len(matches) < args.top_k:
+        remaining = donors.drop(matches.index)
+        extra = remaining.sample(args.top_k - len(matches)) if len(remaining) >= args.top_k - len(matches) else remaining
+        matches = pd.concat([matches, extra])
+    matches = matches.head(args.top_k)
+
+    print(f"Top {args.top_k} donors for event '{event['title']}' ({event['event_id']}):")
+    for _, row in matches.iterrows():
+        print(f"- {row['name']} | Cause: {row['primary_cause']} | Email: {row['communication_pref']}")


### PR DESCRIPTION
## Summary
- simplify event matching script to use donor CSV heuristics
- tweak main CLI to prompt for event_id when matching or simulating KPIs
- default to sample event/donor files

## Testing
- `python -m py_compile match_events.py`
- `python -m py_compile main.py`
- `python match_events.py --events_json sample_events.json --event_id hk001 --donor_csv output/donors_fake.csv --top_k 3`

------
https://chatgpt.com/codex/tasks/task_b_68651a17be1c8333b5bb7658c80ed50e